### PR TITLE
Make `make test` happy

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -10,16 +10,31 @@
 package main_common;
 use base Exporter;
 use Exporter;
-use testapi qw(check_var get_var set_var diag);
+use testapi;
 use autotest;
 use strict;
 use warnings;
 
 our @EXPORT = qw(
+  $live_user_name
+  $live_user_password
+  $live_root_password
   init_main
   loadtest
   set_defaults_for_username_and_password
 );
+
+# Live medium's credentials
+our $live_user_name     = 'jack';
+our $live_user_password = 'jack';
+our $live_root_password = 'openindiana';
+
+sub set_defaults_for_username_and_password {
+    # Installed system's credentials
+    $testapi::username = 'robot';
+    $testapi::password = 'nots3cr3t';
+    $testapi::realname = 'Karel Capek';
+}
 
 sub init_main {
     set_defaults_for_username_and_password();
@@ -28,18 +43,6 @@ sub init_main {
 sub loadtest {
     my ($test) = @_;
     autotest::loadtest("tests/$test.pm");
-}
-
-sub set_defaults_for_username_and_password {
-    # Installed system's credentials
-    $testapi::username = 'robot';
-    $testapi::password = 'nots3cr3t';
-    $testapi::realname = 'Karel Capek';
-
-    # Live medium's credentials
-    $testapi::live_user_name     = 'jack';
-    $testapi::live_user_password = 'jack';
-    $testapi::live_root_password = 'openindiana';
 }
 
 1;

--- a/tests/installation/bootloader_mate.pm
+++ b/tests/installation/bootloader_mate.pm
@@ -21,9 +21,9 @@ sub check_ssh_in_live_environment {
     assert_script_run('pgrep -l sshd');
     my $the_illumos_project = 'The Illumos Project';
     type_string qq(cat > sshlogin.exp <<-END
-spawn ssh -o "StrictHostKeyChecking no" $testapi::live_user_name\@localhost
+spawn ssh -o "StrictHostKeyChecking no" $main_common::live_user_name\@localhost
 expect "assword:"
-send "$testapi::live_user_password\\r"
+send "$main_common::live_user_password\\r"
 expect "$the_illumos_project"
 END\n);
     assert_script_run "expect -f sshlogin.exp | grep --color=always '$the_illumos_project'";


### PR DESCRIPTION
Was failing with:
```
Name "testapi::live_user_password" used only once: possible typo at
lib/main_common.pm line 41.
Name "testapi::live_user_name" used only once: possible typo at
lib/main_common.pm line 40.
Name "testapi::live_root_password" used only once: possible typo at
lib/main_common.pm line 42.
```

And replace tabs with spaces and remove useless inherited stuff.

Verification run: http://localhost/tests/1073