### PR TITLE
UEFI: Disable Secure Boot & boot to MATE with enabled sshd

### DIFF
--- a/products/openindiana/main.pm
+++ b/products/openindiana/main.pm
@@ -2,7 +2,7 @@
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
 # Copyright © 2012-2017 SUSE LLC
-# Copyright © 2017 Michal Nowak
+# Copyright © 2017-2018 Michal Nowak
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -74,6 +74,7 @@ my $brf     = get_var('BOOTLOADER_REGRESSION_FEATURE');
 
 my $vmm_family = get_var('VIRSH_VMM_FAMILY');
 loadtest "installation/bootloader_$vmm_family" if $vmm_family;
+loadtest 'boot/disable_uefi_secure_boot' if get_var('UEFI');
 if (get_var('HDD_1')) {
     loadtest 'boot/boot_from_hdd';
 }

--- a/tests/boot/disable_uefi_secure_boot.pm
+++ b/tests/boot/disable_uefi_secure_boot.pm
@@ -1,0 +1,48 @@
+# OpenIndiana's openQA tests
+#
+# Copyright © 2018 Michal Nowak
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disable UEFI Secure Boot
+# Maintainer: Michal Nowak <mnowak@startmail.com>
+
+use base 'installbasetest';
+use strict;
+use testapi;
+
+sub run {
+    assert_screen('uefi-firmware-banner');
+    send_key_until_needlematch('uefi-menu-home', 'f2', 10, 0.5);
+    send_key 'down';
+    send_key 'ret';
+    assert_screen('uefi-menu-device-manager');
+    send_key 'ret';
+    assert_screen('uefi-menu-secure-boot-configuration');
+    send_key 'down';
+    send_key 'ret';
+    assert_screen('uefi-menu-secure-boot-configuration-changed');
+    send_key 'ret';
+    send_key 'f10';
+    assert_screen('uefi-menu-save-configuration');
+    send_key 'y';
+    send_key 'esc';
+    assert_screen('uefi-menu-device-manager');
+    send_key 'esc';
+    send_key_until_needlematch('uefi-menu-home-continue-button', 'down', 10);
+    send_key 'ret';
+    assert_screen('uefi-menu-reset-now');
+    send_key 'ret';
+    assert_screen('uefi-firmware-banner');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/installation/bootloader_mate.pm
+++ b/tests/installation/bootloader_mate.pm
@@ -33,7 +33,8 @@ END\n);
 sub run() {
     pre_bootmenu_setup;
     bootloader_dvd;
-    firstboot_setup;
+    # On UEFI illumos vga console is currently not initialized
+    firstboot_setup unless get_var('UEFI');
     # LightDM login is not present on Live medium
     assert_mate;
     mouse_hide;


### PR DESCRIPTION
Currently we are able to boot to MATE with sshd enabled in boot menu on
UEFI with Secure Boot disabled in the firmware as 'Enable ssh' option in
boot loader disables questions on language & locate on vga console which
illumos currently can't initialize.

Requires: https://github.com/OpenIndiana/os-autoinst-needles-openindiana/pull/7