### PR TITLE
After QEMU backend changes USB disk can be selected via key '1'

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -110,7 +110,7 @@ sub pre_bootmenu_setup {
         assert_screen 'sea-bios-splash', 5;
         send_key 'esc';
         assert_screen 'boot-menu-usb', 4;
-        send_key(2 + get_var('NUMDISKS') + get_var('QEMU_NO_FDC_SET', 0));
+        send_key(1);
     }
 }
 


### PR DESCRIPTION
https://openqa.oi.mnowak.cz/tests/3693