### PR TITLE
Prolong upload_asset() timeout to 15 minutes

### DIFF
--- a/tests/toolchain/distribution_constructor.pm
+++ b/tests/toolchain/distribution_constructor.pm
@@ -1,6 +1,6 @@
 # OpenIndiana's openQA tests
 #
-# Copyright © 2017 Michal Nowak
+# Copyright © 2017-2018 Michal Nowak
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -47,7 +47,7 @@ sub run {
         my $upload_filename_path = "$dc_root/media/$upload_filename";
         assert_script_sudo "mv $dc_root/media/OpenIndiana_${variant}_X86.$medium $upload_filename_path";
         for (1 .. 5) {    # Try to upload image up to five times
-            last unless upload_asset($upload_filename_path, 1, 0, 600);
+            last unless upload_asset($upload_filename_path, 1, 0, 900);
         }
         record_info("$variant$medium", "$upload_filename uploaded successfully");
         # Save some space on openQA worker as OS image takes 40-45 GB


### PR DESCRIPTION
USB images are bigger and their upload sometimes fails, prolong the
timeout to 15 minutes.