### PR TITLE
Do not run sudo as root

### DIFF
--- a/tests/installation/firstboot.pm
+++ b/tests/installation/firstboot.pm
@@ -30,9 +30,7 @@ sub run {
         pkg_set_flush_content_cache if get_var('PUBLISH_HDD_1');
         if (is_minimal) {
             # Can't use pkg_call() as we likely don't have sudo in Minimal install, yet
-            assert_script_run('pkg info sudo wget || pkg install sudo wget', 700);
-            # Test assert_script_sudo(). Makes sure we have both `sudo` and `wget`.
-            assert_script_sudo('pkg info wget');
+            assert_script_run('pkg list sudo wget || pkg install sudo wget', 700);
         }
         else {
             assert_script_run("sed -i '/$testapi::username/d' /etc/sudoers");


### PR DESCRIPTION
Since `sudo` 1.8.23 "PAM account management modules and BSD auth
approval modules are now run even when no password is required". Hence
`sudo` as root fails with: `root : PAM account management error:
Permission denied`.

Fails here: https://openqa.oi.mnowak.cz/tests/4190#step/firstboot/13
Validation run: https://openqa.oi.mnowak.cz/tests/4235